### PR TITLE
correct GetActiveProfileEffects() handling for user paths

### DIFF
--- a/sfx-100-streamdeck-sfb-extension/Properties/AssemblyInfo.cs
+++ b/sfx-100-streamdeck-sfb-extension/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
 // indem Sie "*" wie unten gezeigt eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.3.0")]
-[assembly: AssemblyFileVersion("0.0.3.0")]
+[assembly: AssemblyVersion("0.0.3.1")]
+[assembly: AssemblyFileVersion("0.0.3.1")]

--- a/sfx-100-streamdeck-sfb-extension/SimFeedbackInvoker.cs
+++ b/sfx-100-streamdeck-sfb-extension/SimFeedbackInvoker.cs
@@ -239,6 +239,20 @@ namespace sfx_100_streamdeck_sfb_extension
 
             string path = Directory.GetCurrentDirectory();
             var profileDir = Path.Combine(path,"profiles");
+            // If a user profile path (e.g. "-p profiles.user") is given, reassign profileDir to the correct path
+            string[] arguments = Environment.GetCommandLineArgs();
+
+            bool found = false;
+            foreach (var s in arguments)
+            {
+                if (found) // Next argument should be the userpath 
+                { 
+                    profileDir = Path.Combine(path,s); 
+                    found = false; 
+                }
+                if (s == "-p") found = true;
+            }
+            GuiLoggerProvider.Instance.Log("profileDir: " + profileDir);
 
             var profileFiles = Directory.GetFiles(profileDir, "*.xml", SearchOption.AllDirectories);
 


### PR DESCRIPTION
If a user profile path (e.g. "-p profiles.user") is given, reassign profileDir to the correct path.